### PR TITLE
Fix bug of eslint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "tsc": "tsc",
     "test": "jest",
     "production": "NODE_ENV=production webpack -p --config webpack.config.prod.js",
-    "lint": "eslint src/**/**/*.ts && eslint src/**/**/*.tsx"
+    "lint": "eslint src --ext .ts,.tsx"
   },
   "author": "hyochan",
   "license": "MIT",


### PR DESCRIPTION
### Problem:
```
eslint src/**/**/*.ts && eslint src/**/**/*.tsx
```
with current command like above, on some shell environments, it only checks up until 2-level-deep from the `src` files.

---
### Solution:
when using glob pattern, the [result could be vary by shells](https://eslint.org/docs/user-guide/command-line-interface)

so it is good to use **double qoute** then it would work well in general

    eslint "src/**/*.ts" && eslint "src/**/*.tsx"
> side note: using double asterisk `/**/` once is fine
---
### Better solution: 
And for the simpler solution we can use

    eslint src --ext .ts,.tsx

this will check all files under `src` directory with `ts` and `tsx` files correctly