### PR TITLE
Put Service Worker in Public Folder

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,13 +1,10 @@
-/// <reference lib="webworker" />
+'use strict';
 
-const worker = self as unknown as ServiceWorkerGlobalScope;
 const CACHE = 'network-or-cache';
-/** How long to wait before hitting cache. */
-const TIMEOUT = 500;
 
 // Open a cache and use `addAll()` with an array of assets to add all of them
 // to the cache. Return a promise resolving when all the assets are added.
-const precache = async (): Promise<void> => {
+const precache = async () => {
   const cache = await caches.open(CACHE);
 
   await cache.addAll([
@@ -17,10 +14,7 @@ const precache = async (): Promise<void> => {
 
 // Time limited network request. If the network fails or the response is not
 // served before timeout, the promise is rejected.
-const fromNetwork = async (
-  request: Request,
-  timeout: number,
-): Promise<Response> => {
+const fromNetwork = async (request, timeout) => {
   const timeoutId = setTimeout(
     () => { throw new Error('Request timeout.'); },
     timeout,
@@ -36,19 +30,19 @@ const fromNetwork = async (
 // Open the cache where the assets were stored and search for the requested
 // resource. Notice that in case of no matching, the promise still resolves
 // but it does with `undefined` as value.
-const fromCache = async (request: Request): Promise<Response> => {
+const fromCache = async (request) => {
   const cache = await caches.open(CACHE);
   const matching = await cache.match(request);
 
   if (matching === undefined) {
-    throw new Error('no-match');
+    throw new Error('no match');
   }
 
   return matching;
 };
 
 // On install, cache some resource.
-worker.addEventListener('install', (evt) => {
+self.addEventListener('install', (evt) => {
   console.log('The service worker is being installed.');
 
   // Ask the service worker to keep installing until the returning promise
@@ -58,14 +52,11 @@ worker.addEventListener('install', (evt) => {
 
 // On fetch, use cache but update the entry with the latest contents
 // from the server.
-worker.addEventListener('fetch', function(evt) {
+self.addEventListener('fetch', function(evt) {
   console.log('The service worker is serving the asset.');
 
   // Try network and if it fails, go for the cached copy.
-  // evt.respondWith(fromNetwork(evt.request, 4000).catch(function() {
-  //   return fromCache(evt.request);
-  // }));
-  evt.respondWith(
-    fromNetwork(evt.request, TIMEOUT).catch(() => fromCache(evt.request)),
-  );
+  evt.respondWith(fromNetwork(evt.request, 4000).catch(function() {
+    return fromCache(evt.request);
+  }));
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,11 +11,10 @@ module.exports = {
   target: 'web',
   entry: {
     app: './src/App.tsx',
-    'service-worker': './src/service-worker.ts',
   },
   output: {
     path: path.resolve(__dirname, './dist'),
-    filename: '[name].js',
+    filename: 'bundle.js',
     publicPath: '/',
   },
   plugins: [

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -8,11 +8,10 @@ module.exports = {
   mode: 'production',
   entry: {
     app: './src/App.tsx',
-    'service-worker': './src/service-worker.ts',
   },
   output: {
     path: path.resolve(__dirname, './dist'),
-    filename: '[name].js',
+    filename: 'bundle.js',
     publicPath: '/',
   },
   plugins: [


### PR DESCRIPTION
### Problem
Making service worker as a webpack entry blocks fash refresh.

### To Be
- Remove `service-worker` entry from webpack.
- Rename webpack output name to `bundle.js`.
- Move `src/service-worker.ts` to `public/service-worker.js`.