### PR TITLE
Add historyApiFallback option to webpack dev server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,7 @@ module.exports = {
     extensions: ['.ts', '.tsx', '.js', 'jsx'],
   },
   devServer: {
+    historyApiFallback: true,
     static: {
       directory: path.join(__dirname, '/src'),
     },


### PR DESCRIPTION
## Description
If you try to access the path which is not the root directly(ex. http://localhost:8080/temp) on development mode, you could see a 404 page like below picture. With [historyApiFall](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback) option, you can access the page you want directly since `devServer` can serve `index.html` file on the path which is not the root.


<img width="500" alt="Screen Shot 2022-07-16 at 8 43 54 PM" src="https://user-images.githubusercontent.com/58724686/179353443-8c11d746-d432-4f19-928c-39e22932f299.png">